### PR TITLE
fix obsolete include syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,11 @@
 - include_tasks: onion_service.yml
   when: use_onion_service
 
-- include_tasks: open_fw.yml ssh_port="22"
+- include_tasks: open_fw.yml
+  vars:
+    ssh_port: 22
 
-- include_tasks: open_fw.yml ssh_port={{ ansible_port }}
+- include_tasks: open_fw.yml
+  vars:
+    ssh_port: "{{ ansible_port }}"
   when: ansible_port is defined and ansible_port != "22"


### PR DESCRIPTION
breaks with Ansible 2.7