### PR TITLE
Filter by default the ciphers deemed insecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,38 @@ $ cat deploy_ssh.yml
 ```
 
 The generated hostname will be in `/var/lib/tor/onion_service_ssh/hostname`
+
+# Filtering ciphers and various cryptographic algos
+
+For security reasons, if people need to remove specific ciphers, this can be
+achieved with the `filters` option. This can be used for now on cipers and MAC,
+and requires to either give the exact name in the `to_remove` list, or a regexp
+in `to_remove_re`.
+
+For example, to remove arcfour and 2 md5 based mac (out of 3), the following
+snippet can be used:
+```
+$ cat deploy_ssh.yml
+- hosts: all
+  roles:
+  - role: openssh
+    use_onion_service: True
+    filters:
+      ciphers:
+        to_remove_re:
+        - arcfour
+      macs:
+        to_remove:
+        - hmac-md5-96
+        - hmac-md5
+```
+
+Others options may be added, see vars/main.yml for the options that can be affected.
+For now, only `ciphers` and `macs` are officialy supported. The others can have their name
+changed.
+
+The system try to be as safe as possible to avoid breakage since openssh is
+critical for ansible, see the commit log for more precisions.
+
+Since this requires a ssh client that support -Q argument for autodetection of
+the supported ciphers, anything else will be untouched, out of conservatism.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,13 @@
 use_onion_service: False
+filters:
+  ciphers:
+    # remove one ore more specific ciphers
+    # not matching using a regexp
+    to_remove: []
+
+    # same, but using the ciphers as regexp, used
+    # to stop a whole set of ciphers in 1 go
+    to_remove_re: []
+  macs:
+    to_remove: []
+    to_remove_re: []

--- a/tasks/filter_algo.yml
+++ b/tasks/filter_algo.yml
@@ -1,0 +1,53 @@
+- name: Combine the filters with deployment information
+  set_fact:
+    filters: "{{ filters | combine(filters_info,recursive=True) }}"
+
+- name: Try to get the list of supported algos
+  command: "ssh -Q {{ filters[filter]['dash_q'] }}"
+  register: q_list
+  changed_when: False
+  ignore_errors: True
+
+- name: Set the list of possible algos
+  set_fact:
+    possible_algos: "{{ q_list.stdout.split('\n') }}"
+
+- name: Create the regexp to filter the algos
+  set_fact:
+    re_also_remove: "^(.*{{ filters[filter]['to_remove_re'] | default([]) | join ('.*|.*') }}.*)$"
+  when: filters[filter]['to_remove_re'] | default([]) | length |int > 0
+
+- name: Create the list of algos to remove
+  set_fact:
+    #  https://stackoverflow.com/questions/38795908/how-to-select-regex-matches-in-jinja2
+    to_remove_algos: "{{ possible_algos | map('regex_search', re_also_remove) | select('string') | list }}"
+
+- name: Compute the new configurated algos
+  set_fact:
+    config_algos: "{{ possible_algos | difference(filters[filter]['to_remove'] | default([])) | difference(to_remove_algos) }}"
+
+- name: Check if there was a change in algos
+  set_fact:
+    algos_diff: "{{ possible_algos | symmetric_difference(config_algos) | length | int }}"
+
+- name: Fail if there is not enough suitable algos (like a error filtering all)
+  fail:
+    msg: "Not enough suitable algos found for {{ filter }}, failling to avoid having a wrong configuration"
+  when: q_list.rc == 0 and (config_algos | length | int) <= 3
+
+- name: Set the configuration
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^{{ filters[filter]['config'] }}"
+    line: "{{ filters[filter]['config'] }} {{ config_algos |join(',') }}"
+    state: present
+  notify: verify config and restart sshd
+  when: q_list.rc == 0 and algos_diff != 0
+
+- name: Clear the configuration
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^{{ filters[filter]['config'] }}"
+    state: absent
+  notify: verify config and restart sshd
+  when: q_list.rc == 0 and algos_diff == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,3 +32,11 @@
   vars:
     ssh_port: "{{ ansible_port }}"
   when: ansible_port is defined and ansible_port != "22"
+
+- import_tasks: filter_algo.yml
+  vars:
+    filter: ciphers
+
+- import_tasks: filter_algo.yml
+  vars:
+    filter: macs

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,17 @@
+re_also_remove: "^$"
+
+filters_info:
+  ciphers:
+    dash_q: "cipher"
+    config: "Ciphers"
+  macs:
+    dash_q: "mac"
+    config: "MACs"
+  keys:
+    dash_q: "key"
+    config: "HostKeyAlgorithms"
+  key_exchanges:
+    dash_q: "kex"
+    config: "KexAlgorithms"
+# PubkeyAcceptedKeyTypes
+# HostbasedAcceptedKeyTypes


### PR DESCRIPTION
While upstream think they are ok and being kept
for compatibility, some organisations disagree and
give poor ratings impacting my employer. Since
that's automated, that's a easy way to scam customers.

Since openssh is critical and even more with ansible, this modification
try to be as conservative as possible and try to avoid any critical
outage by making sure changes are future proofed, without requiring
on-going maintenance.

For example, there is no hardcoding of the list of ciphers, in case
some are removed in the future and still in the list, since openssh
fail to start if a cipher is requested but was removed. This is to prevent
ciphers list rot, which is a problem that could happen if we have to do any
manual maintenance.

The system also clean itself for future proofing as well (if upstream
drop the problematic ciphers, then we do switch to use upstream list without
modification).

And we check we do not do something stupid before even writing
the configuration.

The resulting code is more complex than I like, but mostly because
upstream do not let use give a list of ciphers we want to avoid,
just a list we want to use.